### PR TITLE
[Feature] Custom Formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - 1.2.3 Bugfix: https://github.com/misthero/dnd5e-spellpoints/issues/13.
 - 1.2.4 Feature: Disable Spell Point switch on character sheet when sheet is locked. https://github.com/misthero/dnd5e-spellpoints/issues/14
 - 1.2.5 Bugfix: Restored mixed mode checkbox on certain character sheets
+- 2.0.0 Add configurable custom formula for max spell point calculation. Hard coded lists of maximum spell points are no longer valid, making this a breaking change. 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Advanced Magic - Spell Points System 5e
 FoundryVTT module for Spell Point System in D&D5e
- 
+
 **Not using spellpoints for your games? well, you should, spellpoints are much better than slots!!**
- 
-This module use the optional rules found on DMG to allow character to cast spells using a resource named "Spell Points"
- 
+
+This module uses the optional rules found in the DMG to allow character to cast spells using a resource named "Spell Points"
+
 ## Changelog
 https://github.com/misthero/dnd5e-spellpoints/blob/main/CHANGELOG.md
- 
+
 ## Installation Instructions
 - Copy "https://raw.githubusercontent.com/misthero/dnd5e-spellpoints/main/module.json" into the module installer inside foundry when it asks for the manifest.
 - Launch your world go to settings -> module settings and enable the module `dnd5e-spellpoints`.
 - Choose the name of the resource to use as Spell Points (default "Spell Points") you can change the name in module settings.
 - Create a new resource with the name "Spell Points" on every character sheet. (Hint: if any of your player need more resources you can use the module https://github.com/ardittristan/5eSheet-resourcesPlus/tree/master)
-- The module will calculate Spell Points automatically when you add a new class item or level up your class (only offical rules supported, if you are using hombrew rules you should disable the automatic mode.
+- The module will calculate Spell Points automatically when you add a new class item or level up your class. You can even create your own formula for calculating Spell Points.
 
 
 You are ready to go, now spells cast by player's characters will use spell points instead of slots.
@@ -22,15 +22,63 @@ You are ready to go, now spells cast by player's characters will use spell point
 **Notice**: Slots won't disappear from character sheets, but they will always stay full as long as this module is enabled.
 
 ## Features
-- Configurable resource name
-- Configurable spell cost in spell points if you use any homebrew system.
+- Configurable resource name.
+- Configurable formulas. All numerical fields are powered by FoundryVTT's Roll class. This not only give you access to functions like `round` and `kh` but also data within the characters themselves such as `@details.level` or `@abilities.cha.mod`. See [Data Paths as Variables](https://foundryvtt.com/article/dice-advanced/) for more information. The following fields are formulas:
+    - SpellPoint Costs
+    - SpellPointMaximum Base Formula (applied only if the character has at least one spell slot)
+    - SpellPointMaximum Slot Multiplier (multiplies the cost of all spell slots the character would have). To reproduce the formula in the DMG, leave this as `1`.
+    - Health Penalty Multiplier (See **[Advanced Magic - Spell Point System 5e!](https://www.drivethrurpg.com/product/272967/Advanced-Magic--Spell-Points-System-5e)** for more information).
 - Optionally you can enable a variant rule to allow players to keep casting even when they run out of spellpoints using their own life with terrible consequences if you are using the **[Advanced Magic - Spell Point System 5e!](https://www.drivethrurpg.com/product/272967/Advanced-Magic--Spell-Points-System-5e)** available as "Pay what you Want" on DriveThruRPG.
-- Configurable healt loss for casting using the Gritty High Magic Variant.
+
+## Example Max Spell Points Formulas
+
+### DMG
+By the DMG, a character will always have enough spell points to create the spell slots they would normally have. This can be calculated by starting with `0` and  adding up the spell point cost of every slot they would normally have, multiplying it by `1`.
+* If you adjust the Spell Point costs, character maximum spell points will adjust when they level up.
+* If you edit the spell slots a character has, their maximum spell points will adjust when they level up.
+
+
+Base Formula
+```
+0
+```
+
+Spell Point Multiplier
+```
+1
+```
+
+
+### Advanced Magic
+See the [Advanced Magic](https://www.dmsguild.com/product/272967/Advanced-Magic--Spell-Points-System-5e) spell point system for why characters may not always have enough spell points to cast all of their normal spell slots.
+
+Base Formula
+```
+ceil(
+  (
+    1 * @spells.spell1.max +
+    2 * @spells.spell2.max +
+    3 * @spells.spell3.max +
+    4 * @spells.spell4.max +
+    5 * @spells.spell5.max +
+    6 * @spells.spell6.max +
+    7 * @spells.spell7.max +
+    8 * @spells.spell8.max +
+    9 * @spells.spell9.max
+  ) / 2
+)
++
+@attributes.spelldc - 8 - @attributes.prof
+```
+
+Spell Point Multiplier
+```
+0
+```
+
 
 ## To do
-- Automatic Spell Point calculations based on class and level.
-- Show the sell cost on each spell somewhere?
+- Add configurable limit to number of times a spell slot can be generated per day. This would reproduce the limit within the DMG that only allows creatures to make one 6th+ level slot per day of the same level.
 
 ### Incompatibility
 None at the moment but please let me know if any.
-

--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
 
 .spEnable {
   flex:0 0 25px;
-  
+
 }
 .spEnable > label {
   cursor:pointer;
@@ -24,7 +24,7 @@
   width:0 !important;
   height:0 !important;
   overflow:hidden;
-  position:absolute; 
+  position:absolute;
 }
 
 input.spEnableInput.visually-hidden + .spEnableCheck:before {
@@ -51,3 +51,8 @@ input.spEnableInput.visually-hidden:checked + .spEnableCheck:before {
 .tidy5e-sheet.allow-edit .spEnable .no-edit {display:none;}
 .tidy5e-sheet .spEnable .edit-allowed { display:none;}
 .tidy5e-sheet.allow-edit .spEnable .edit-allowed { display:block;}
+
+textarea.spellPoints {
+  width: 100%;
+  resize: none;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,9 +9,6 @@
   "dnd5e-spellpoints.mixedMode": "With Mixed Mode enabled every character will get the option to enable Spell Points directly in the character sheet.",
   "dnd5e-spellpoints.autoLabel": "Enable Automatic spell points calculation",
   "dnd5e-spellpoints.autoNote": "Enable this settings if you want the module do the math for you every time a Player Character advance in a Class Level or gain a new Class",
-  "dnd5e-spellpoints.formulaLabel": "Automatic spell points calculation formula",
-  "dnd5e-spellpoints.formulaNote": "What formula should this module use to calculate the maximum PC spell points (default: DMG).",
-  "dnd5e-spellpoints.formulaNote2": "Choosing Advanced Magic (homebrew), spell points will be calculated accordingly to the free homebrew module \"Advanced Magic - Spell Points System 5e\" available for free on",
   "dnd5e-spellpoints.AMLinkLabel": "Dungeon Masters Guild Website",
   "dnd5e-spellpoints.DMG": "Dungeon Master Guide",
   "dnd5e-spellpoints.AM": "Advanced Magic (homebrew)",
@@ -37,5 +34,10 @@
   "dnd5e-spellpoints.spellCost": "Costs {amount} {SpellPoints}",
   "dnd5e-spellpoints.spellUsingSpellPoints": "{ActorName} casted a spell using {spellPointUsed} {SpellPoints}. {remainingPoints} {SpellPoints} remaining.",
   "dnd5e-spellpoints.save": "Save",
-  "dnd5e-spellpoints.reset": "Reset"
+  "dnd5e-spellpoints.reset": "Reset",
+  "dnd5e-spellpoints.spellPointsFormula": "Max Spell Points Formula",
+  "dnd5e-spellpoints.formulaBaseLabel": "Base Formula",
+  "dnd5e-spellpoints.formulaSlotLabel": "Slot Formula",
+  "dnd5e-spellpoints.formulaBaseNote": "The base formula is added if the character has at least one spell slot.",
+  "dnd5e-spellpoints.formulaSlotNote": "The slot formula multiplies the total Spell Point costs of the slots that the character would have."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -9,9 +9,6 @@
   "dnd5e-spellpoints.mixedMode": "Con el modo Mixto habilitado, cada personaje tendrá la opción de habilitar los Puntos de Conjuro en su ficha.",
   "dnd5e-spellpoints.autoLabel": "Habilitar cálculo automático de Puntos de Conjuro",
   "dnd5e-spellpoints.autoNote": "Activa esta opción si quieres que el módulo haga el cálculo por ti cada vez que un personaje avance niveles en una Clase o gane una nueva Clase",
-  "dnd5e-spellpoints.formulaLabel": "Fórmula de cálculo de Puntos de Conjuro automático",
-  "dnd5e-spellpoints.formulaNote": "Qué fórmula debería usar este módulo para calcular los Puntos de Conjuro máximos de los PJ (defecto: DMG).",
-  "dnd5e-spellpoints.formulaNote2": "Si eliges Magia Avanzada (regla casera), los puntos de conjuro se calcularán según el módulo casero \"Advanced Magic - Spell Points System 5e\", disponible sin coste alguno en la",
   "dnd5e-spellpoints.AMLinkLabel": "Página web de la Dungeon Masters Guild",
   "dnd5e-spellpoints.DMG": "Guía del Dungeon Master",
   "dnd5e-spellpoints.AM": "Magia Avanzada (regla casera)",
@@ -37,5 +34,10 @@
   "dnd5e-spellpoints.spellCost": "Cuesta {amount} {SpellPoints}",
   "dnd5e-spellpoints.spellUsingSpellPoints": "{ActorName} ha lanzado un conjuro usando {spellPointUsed} {SpellPoints}. Le quedan {remainingPoints} {SpellPoints}.",
   "dnd5e-spellpoints.save": "Guardar",
-  "dnd5e-spellpoints.reset": "Reiniciar"
+  "dnd5e-spellpoints.reset": "Reiniciar",
+  "dnd5e-spellpoints.spellPointsFormula": "Fórmula de Puntos Máximos de Hechizos",
+  "dnd5e-spellpoints.formulaBaseLabel": "Fórmula Base",
+  "dnd5e-spellpoints.formulaSlotLabel": "Fórmula de Ranura",
+  "dnd5e-spellpoints.formulaBaseNote": "La fórmula base se agrega si el personaje tiene al menos un espacio para hechizos.",
+  "dnd5e-spellpoints.formulaSlotNote": "La fórmula de la tragamonedas multiplica los costos totales de Puntos de Hechizo de las tragamonedas que tendría el personaje."
 }

--- a/lang/it.json
+++ b/lang/it.json
@@ -9,9 +9,6 @@
   "dnd5e-spellpoints.mixedMode": "Con la Modalità Mista ogni personaggio avrà la possibilità di abilitare i Punti Magia o rimanere col sistema degli Slot direttamente dalla propria Scheda del Personaggio.",
   "dnd5e-spellpoints.autoLabel": "Abilita Calcolo Automatico dei Punti Magia",
   "dnd5e-spellpoints.autoNote": "Con questa impostazione i punti Magia saranno calcolati in automatico quando un Personaggio avanza in un Livello di Classe o ottiene una nuova Classe.",
-  "dnd5e-spellpoints.formulaLabel": "Formula per il calcolo automatico",
-  "dnd5e-spellpoints.formulaNote": "Quale formula utilizzare per calcolare i Punti Magia. (default: DMG).",
-  "dnd5e-spellpoints.formulaNote2": "Choosing Advanced Magic (homebrew), spell points will be calculated accordingly to the free homebrew module \"Advanced Magic - Spell Points System 5e\" available for free on",
   "dnd5e-spellpoints.AMLinkLabel": "sito Dungeon Masters Guild",
   "dnd5e-spellpoints.DMG": "Guida del Dungeon Master",
   "dnd5e-spellpoints.AM": "Advanced Magic (homebrew)",
@@ -39,5 +36,10 @@
   "dnd5e-spellpoints.spellCost": "Costa {amount} {SpellPoints}",
   "dnd5e-spellpoints.spellUsingSpellPoints": "{ActorName} ha utilizzato {spellPointUsed} {SpellPoints}. Gli rimangono {remainingPoints} {SpellPoints}.",
   "dnd5e-spellpoints.save": "Salva",
-  "dnd5e-spellpoints.reset": "Ripristina"
+  "dnd5e-spellpoints.reset": "Ripristina",
+  "dnd5e-spellpoints.spellPointsFormula": "Formula di Punti Incantesimo Massimi",
+  "dnd5e-spellpoints.formulaBaseLabel": "Formula di Base",
+  "dnd5e-spellpoints.formulaSlotLabel": "Formula di Slot",
+  "dnd5e-spellpoints.formulaBaseNote": "La formula base viene aggiunta se il personaggio ha almeno uno slot incantesimo.",
+  "dnd5e-spellpoints.formulaSlotNote": "La formula dello slot moltiplica i costi totali in punti incantesimo degli slot che il personaggio avrebbe."
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "dnd5e-spellpoints",
     "title": "Advanced Magic - Spell Points System 5e",
     "description": "FoundryVTT module for Spell Points System in D&D5e. This module use the optional rules found on DMG to allow character to cast spells using a resource named 'Spell Points'",
-    "version": "1.2.5",
+    "version": "2.0.0",
     "minimumCoreVersion": "0.8.3",
     "compatibleCoreVersion": "0.8.9",
     "url": "https://github.com/misthero/dnd5e-spellpoints",

--- a/templates/spellpoint-config.html
+++ b/templates/spellpoint-config.html
@@ -7,41 +7,44 @@
       <input type="text" name="spResource" data-dtype="string" value="{{ spResource }}"/>
       <p class="notes">{{localize "dnd5e-spellpoints.resourceNote"}}</p>
     </div>
-    
+
     <div class="form-group">
       <label>{{localize "dnd5e-spellpoints.mixedLabel"}}</label>
       <input type="checkbox" name="spMixedMode" data-dtype="Boolean" {{checked spMixedMode}}/>
       <p class="notes">{{localize "dnd5e-spellpoints.mixedMode"}}</p>
     </div>
-      
+
     <div class="form-group">
       <label>{{localize "dnd5e-spellpoints.autoLabel"}}</label>
       <input type="checkbox" name="spAutoSpellpoints" data-dtype="Boolean" {{checked spAutoSpellpoints}}/>
       <p class="notes">{{localize "dnd5e-spellpoints.autoNote"}}</p>
     </div>
 
-    <div class="form-group">
-      <label>{{localize "dnd5e-spellpoints.formulaLabel"}}</label>
-      <select name="spFormula" style="flex: 1;">
-        {{#select spFormula}}
-          {{#each spFormulas as |name key|}}
-            <option value="{{key}}">{{name}}</option>
-          {{/each}}
-        {{/select}}
-      </select>
-      <p class="notes">{{localize "dnd5e-spellpoints.formulaNote"}}</p>
-      <!-- <p class="notes">{{localize "dnd5e-spellpoints.formulaNote2"}} <a href="https://www.dmsguild.com/product/272967/Advanced-Magic--Spell-Points-System-5e">{{localize "dnd5e-spellpoints.AMLinkLabel"}}</a></p> -->
-    </div>
     <hr>
     <p><b>{{localize "dnd5e-spellpoints.spellPointsCostsTitle"}}</b></p>
     {{#each spellPointsCosts as |cost level|}}
     <div class="form-group">
-      <label>{{ spFormat "dnd5e-spellpoints.costLabel" slotLevel=level }}</label>
-      <input style="flex:0.2;text-align:right;" max="999" min="0" size="3" name="spellPointsCosts.{{level}}" value="{{ cost }}" type="number" data-dtype="number"/>
+        <div><label>{{ spFormat "dnd5e-spellpoints.costLabel" slotLevel=level }}</label></div>
+        <div><textarea class="spellPoints" rows="1" name="spellPointsCosts.{{level}}">{{ cost }}</textarea></div>
     </div>
     {{/each}}
-    <p>{{localize "dnd5e-spellpoints.spellPointsCostsNote"}}</p>
-    
+    <p class="notes">{{localize "dnd5e-spellpoints.spellPointsCostsNote"}}</p>
+
+    <hr>
+    <p><b>{{localize "dnd5e-spellpoints.spellPointsFormula"}}</b></p>
+    <div class="form-group">
+      <div><label>{{localize "dnd5e-spellpoints.formulaBaseLabel"}}</label></div>
+      <div><textarea class="spellPoints" rows="1" name="spCustomFormulaBase">{{ spCustomFormulaBase }}</textarea></div>
+      <p class="notes">{{localize "dnd5e-spellpoints.formulaBaseNote"}}</p>
+    </div>
+
+    <div class="form-group">
+      <div><label>{{localize "dnd5e-spellpoints.formulaSlotLabel"}}</label></div>
+      <div><textarea class="spellPoints" rows="1" name="spCustomFormulaSlotMultiplier">{{ spCustomFormulaSlotMultiplier }}</textarea></div>
+      <p class="notes">{{localize "dnd5e-spellpoints.formulaSlotNote"}}</p>
+    </div>
+
+
     <hr>
     <p><b>{{localize "dnd5e-spellpoints.AMTitle"}}</b></p>
     <p class="notes">{{localize "dnd5e-spellpoints.AMNotes"}}</p>
@@ -52,13 +55,13 @@
       <p class="notes">{{localize "dnd5e-spellpoints.enableVariantNote"}}</p>
     </div>
     <div class="form-group">
-      <label>{{localize "dnd5e-spellpoints.spLifeCostLabel"}}</label>
-      <input style="flex:0.2;text-align:right;" max="999" min="0" size="3" type="number" data-dtype="number" name="spLifeCost" value="{{ spLifeCost }}"/>
+      <div><label>{{localize "dnd5e-spellpoints.spLifeCostLabel"}}</label></div>
+      <div><textarea class="spellPoints" rows="1" name="spLifeCost">{{ spLifeCost }}</textarea></div>
       <p class="notes">{{localize "dnd5e-spellpoints.spLifeCostNote"}}</p>
     </div>
 
     <hr>
-    
+
     <div class="form-group" style="margin: 10px;">
       <button type="submit" name="submit">
         <i class="fas fa-save"></i> {{localize "dnd5e-spellpoints.save"}}


### PR DESCRIPTION
Takes advantage of FoundryVTT's [Roll](https://foundryvtt.com/api/Roll.html) to evaluate a string formula with actor data.
```js
  static withActorData(formula, actor) {
    const r = new Roll(formula, actor.data.data);
    r.evaluate();
    return r.total;
  }
```
## Features 
This has been used to
* Allow each individual Spell Point cost to have their own formula
* Allow the hp cost multiplier to have a formula
* Added a new field for a custom max spell points formula.
* Added a new field for a custom formula to multiply the total cost of spell points. The result is added on to the custom max spell points formula.

## Breaking Changes
The following settings have been removed as they would overwrite the custom formulas:
* `spFormula`
* `spellPointsByLevel`

## Usage

### DMG
To reproduce what is in the DMG, which is the default setting,  set the following:

Base Formula
```
0
```

Spell Point Multiplier
```
1
```
I propose that this is better than the previous hardcoded DMG values were for maximum spell points. Now it calculates the total spell point costs of slots for a character even if
* The character's class is unknown
* The character overwrites how many spell slots they have, such as an epic feat that grants an additional 9th level slot
* The spell point costs differ from what the DMG suggests

### Advanced Magic
To reproduce what is in [Advanced Magic](https://www.dmsguild.com/product/272967/Advanced-Magic--Spell-Points-System-5e), the bellow code can be used. To understand this formula please see [Advanced Magic](https://www.dmsguild.com/product/272967/Advanced-Magic--Spell-Points-System-5e).

Base Formula
```
ceil(
  (
    1 * @spells.spell1.max +
    2 * @spells.spell2.max +
    3 * @spells.spell3.max +
    4 * @spells.spell4.max +
    5 * @spells.spell5.max +
    6 * @spells.spell6.max +
    7 * @spells.spell7.max +
    8 * @spells.spell8.max +
    9 * @spells.spell9.max
  ) / 2
)
+
@attributes.spelldc - 8 - @attributes.prof
```

Spell Point Multiplier
```
0
```

A note on the above formula. There is no `@attributes.spellcasting.mod`. There is `@attributes.spelldc` which can be used to reverse engineer a spell casting modifier by subtracting 8 and subtracting the character's proficiency. 

### As Unusual As You Want It

You do not need to reproduce a known formula. You can make your own. Consider

Spell Points cost for Level 1 slots
```
{@currency.cp , 1}kh
```
Spell Points cost for Level 2 slots
```
{@currency.sp, 1}kh 
```

Spell Points cost for Level 3 slots
```
{@currency.ep, 1}kh
```

Spell Points cost for Level 4 slots
```
{@currency.gp, 1}kh 
```


Spell Points cost for Level 5 slots
```
{@currency.pp, 1}kh 
```

Spell Points cost for Level 6 slots
```
{@details.xp.value, 1}kh
```

etc


## Making Your Own Formula

Create a macro with the following script:
```js
console.log(actor.data.data)
```

While selecting a token, execute the macro. Then, look at the console. This will tell you all the data that is available to you when writing a formula.

You can test out a formula by rolling it in chat while selecting a token. The following formula would determine the largest modifier which are typically used for spell casting, and it would roll it in chat. 
```
/roll { @abilities.wis.mod,  @abilities.int.mod,  @abilities.cha.mod}kh
```

It is also possible to add a module or create your own module that edits or adds information to `actor.data.data`. This new information will be available to the formulas with no concerns over compatibility. 

## Edits needed
The following should be looked at
* I cannot read or write Spanish or Italian. I used a free translator tool. Please look at those changes and apply something more sane.