### PR TITLE
[Fix] Async Roll.evaluate()

### DIFF
--- a/scripts/dnd5e-spellpoints.js
+++ b/scripts/dnd5e-spellpoints.js
@@ -100,7 +100,7 @@ class SpellPoints {
    */
   static withActorData(formula, actor) {
     const r = new Roll(formula.toString(), actor.data.data);
-    r.evaluate();
+    r.evaluate({async: false});
     return r.total;
   }
 


### PR DESCRIPTION
Fix for Issue #21

[Roll.evaluate()](https://foundryvtt.com/api/Roll.html#evaluate) now returns a Promise unless the option`{async: false}` is given. This is currently quoted in the documentation as being default behavior in v10, but has come in v9.

