### PR TITLE
Fix: Skip pact when no level value

### DIFF
--- a/scripts/spellpoints.js
+++ b/scripts/spellpoints.js
@@ -385,7 +385,7 @@ export class SpellPoints {
         slotLvl = parseInt(slotLvlTxt.replace(/\D/g, ''));
       }
 
-      if (slotLvl == 0) {
+      if (!slotLvl || slotLvl == 0) {
         continue;
       }
 


### PR DESCRIPTION
Just a small fix for a bug I was having where I had pact in actor.system.spells but no level entry for it.