### PR TITLE
Remove newlines from formula to avoid issues when evaluating rolls

### DIFF
--- a/scripts/spellpoints.js
+++ b/scripts/spellpoints.js
@@ -209,7 +209,7 @@ export class SpellPoints {
    * @return {number} The result of the formula.
    */
   static async withActorData(formula, actor) {
-    formula = formula.toString();
+    formula = formula.toString().replace(/\n/g, " ");
     if (!formula || typeof formula !== 'string' || formula.length == 0) {
       return 0;
     }


### PR DESCRIPTION
This removes newlines from the formula (if any), solving an issue with formulas written with newlines.

---
# Reasoning / Reproduction Steps

I have a formula set up like this
```js
2 * @spells.spell1.max +
3 * @spells.spell2.max +
4 * @spells.spell3.max +
5 * @spells.spell4.max +
6 * @spells.spell5.max
```
and the module throws an error when adding the Spell Points to an actor because Foundry's roll parser transforms `\n3 * @spells.spell2.max` into `\n3`, and it gets immediately refused because `StringTerm` aren't accepted normally.